### PR TITLE
第6行第9行配置重复 使用pip安装报错,如下

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-Migrate==1.8.0
 flask-paginate==0.4.5
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
-flask-paginate==0.4.5
 itsdangerous==0.24
 Jinja2==2.8
 Mako==1.0.4


### PR DESCRIPTION
Double requirement given: flask-paginate==0.4.5 (from -r requirements.txt (line 9)) (already in flask-paginate==0.4.5 (from -r requirements.txt (line 6)), name='flask-paginate')