### PR TITLE
修复在virtualenv环境下无法通过./cobra.py执行的问题

### DIFF
--- a/cobra.py
+++ b/cobra.py
@@ -1,11 +1,13 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import re
 import sys
 
 from cobra import main
 
+
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
     sys.exit(main())
+


### PR DESCRIPTION
- 修改首行为`#!/usr/bin/env python`
- 格式化代码样式，使其符合PEP8